### PR TITLE
Changes tempdir to use $TMPDIR if it exists

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -21,7 +21,7 @@ get_native_download_url () {
   if [[ "${platform}" == "linux" ]]; then
     native_filename="kotlin-native-linux-\d+\.\d+\.\d+.tar.gz"
     grep_option="-P"
-    tempdir=$(mktemp -d asdf-kotlin-native.XXXX)
+    tempdir=$(mktemp -dt asdf-kotlin-native.XXXX)
   elif [[ "${platform}" == "darwin" ]]; then
     native_filename="kotlin-native-macos-\d+\.\d+\.\d+.tar.gz"
     grep_option="-E"
@@ -50,7 +50,7 @@ install () {
   local github_prefix="https://github.com/JetBrains/kotlin/releases"
 
   [ "Linux" = "$(uname)" ] && platform="linux" || platform="darwin"
-  [ "linux" = "${platform}" ] && tempdir=$(mktemp -d asdf-kotlin.XXXX) || tempdir=$(/usr/bin/mktemp -dt asdf-kotlin)
+  [ "linux" = "${platform}" ] && tempdir=$(mktemp -dt asdf-kotlin.XXXX) || tempdir=$(/usr/bin/mktemp -dt asdf-kotlin)
 
   curl -L  "${github_prefix}/download/v${version}/kotlin-compiler-${version}.zip" -o "${tempdir}/kotlin-compiler.zip"
   unzip -qq "${tempdir}/kotlin-compiler.zip" -d "${install_path}"


### PR DESCRIPTION
The current configuration creates a temp dir in the local folder. This
can be problematic because Kotlin takes a long time to download and
install. If you imagine you run the command in a directory where you are
working on another project, this could pose issues for version control
if you need to switch between branches or if you accidentally commit the
tempdir (which normally should be avoided but mistakes are made
sometimes).

This configures the tempdir to be in a global /tmp (which should exist
on Linux and MacOS, the 2 platforms that the script tests for) so that
the user is not blocked.