### PR TITLE
Fix installation of Kotlin/Native

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,12 @@ script:
     echo "Confirming version 1.3.21"
     kotlin -version 2>&1 | grep '1.3.21'
     kotlinc-native -version 2>&1 | grep '1.3.21'
+    echo "Setting kotlin 1.4.30-RC as the default value in ~/.tool-versions"
+    echo "java openjdk-11.0.1" > ~/.tool-versions
+    echo 'kotlin 1.4.30-RC' >> ~/.tool-versions
+    echo "Confirming version 1.4.30-RC"
+    kotlin -version 2>&1 | grep '1.4.30-RC'
+    kotlinc-native -version 2>&1 | grep '1.4.30-RC'
 before_script:
   - git clone https://github.com/asdf-vm/asdf.git asdf
   - . asdf/asdf.sh

--- a/bin/install
+++ b/bin/install
@@ -19,11 +19,11 @@ get_native_download_url () {
   local grep_option=""
   local native_filename=""
   if [[ "${platform}" == "linux" ]]; then
-    native_filename="kotlin-native-linux-\d+\.\d+\.\d+.tar.gz"
+    native_filename="kotlin-native-(prebuilt-)?linux-\d+\.\d+\.\d+[^.]*.tar.gz"
     grep_option="-P"
     tempdir=$(mktemp -dt asdf-kotlin-native.XXXX)
   elif [[ "${platform}" == "darwin" ]]; then
-    native_filename="kotlin-native-macos-\d+\.\d+\.\d+.tar.gz"
+    native_filename="kotlin-native-(prebuilt-)?macos-\d+\.\d+\.\d+[^.]*.tar.gz"
     grep_option="-E"
     tempdir=$(/usr/bin/mktemp -dt asdf-kotlin-native)
   fi


### PR DESCRIPTION
Update the patterns for identifying the Kotlin/Native download artifacts in `bin/install` to include the optional `prebuilt-` part and optional version suffixes (such as `-RC`).

Closes #14

## Motivation and Context

See #14.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Usage examples

```
asdf install kotlin 1.4.30-RC
```

## How Has This Been Tested?

Locally with Docker and Travis CI.

## Checklist:

- [x] I have added tests to cover my changes.
- [x] Local linux/docker tests pass (See [README](https://github.com/asdf-community/asdf-kotlin#locally-with-docker-compose)).

