### PR TITLE
Fix asdf-java reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ kotlin (and [kotlin-native if available](https://github.com/asdf-community/asdf-
 
 ## Requirements
 
-* [Java 6 to 8](http://www.oracle.com/technetwork/java/javase/downloads/index.html) - You may want to try [asdf-java](https://github.com/skotchpine/asdf-java) `asdf plugin-add java https://github.com/skotchpine/asdf-java`
+* [Java 6 to 8](http://www.oracle.com/technetwork/java/javase/downloads/index.html) - You may want to try [asdf-java](https://github.com/halcyon/asdf-java) `asdf plugin-add java https://github.com/halcyon/asdf-java`
 
 ## Install
 


### PR DESCRIPTION
README contains an outdated reference to asdf-java repository. This updates it to one from [asdf-plugins](https://github.com/asdf-vm/asdf-plugins).